### PR TITLE
fix: history.back when there is no next question + make computeNextQu…

### DIFF
--- a/apps/devchoices-next/pages/question/[slug].tsx
+++ b/apps/devchoices-next/pages/question/[slug].tsx
@@ -1,8 +1,8 @@
 import { useRouter } from 'next/router'
 import { questions } from '../../public/assets/data/questions'
-import { useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { QuestionInterface } from '@benjamincode/shared/interfaces'
-import { Button, PageTransitionWrapper, Question } from '@benjamincode/shared/ui'
+import { PageTransitionWrapper, Question } from '@benjamincode/shared/ui'
 import { QuestionContext } from '../_app'
 import Image from 'next/future/image'
 
@@ -39,7 +39,7 @@ export function QuestionPage(props: QuestionPageProps) {
   const [nextQuestion, setNextQuestion] = useState<QuestionInterface>()
   const [voteValues, setVoteValues] = useState<number[]>([0, 0])
 
-  const computeNextQuestion = () => {
+  const computeNextQuestion = useCallback(() => {
     if (slug) {
       const currentQuestion = questionContext.questions.find((q) => q.slug === slug)
 
@@ -53,7 +53,7 @@ export function QuestionPage(props: QuestionPageProps) {
       return nextQuestion
     }
     return null
-  }
+  }, [slug, questionContext.questions])
 
   useEffect(() => {
     // todo replace with values fetched from database
@@ -61,7 +61,9 @@ export function QuestionPage(props: QuestionPageProps) {
   }, [setVoteValues])
 
   useEffect(() => {
-    router.prefetch(`/question/${computeNextQuestion().slug}`).then()
+    const nextQuestion = computeNextQuestion()
+    if (!nextQuestion) return
+    router.prefetch(`/question/${nextQuestion.slug}`).then()
   }, [slug, router, computeNextQuestion])
 
   useEffect(() => {


### PR DESCRIPTION
…estion stable

# What this PR is about?

fix a bug with history.back, steps to reproduce:

- go to `localhost:4200`, you get redirected to `localhost:4200/question/xxx-1`
- click on either answer
- click on next question, you get redirected to `localhost:4200/question/yyy-1`
- click back on browser / mobile, you get redirected to `localhost:4200/question/xxx-1`
- click back, you get redirect to `localhost:4200` for a second, that's when it crashes (before this PR)
- and then it redirects back to `localhost:4200/question/xxx-1` (after this PR)

### Tests

- [ ] I have run the tests of the project. `nx affected --target=test `

### Clean Code

- [x] I made sure the code is type safe (no any)
