### PR TITLE
Add e2e tests with cypress

### DIFF
--- a/apps/devchoices-next-e2e/cypress.config.ts
+++ b/apps/devchoices-next-e2e/cypress.config.ts
@@ -2,5 +2,8 @@ import { defineConfig } from 'cypress'
 import { nxE2EPreset } from '@nrwl/cypress/plugins/cypress-preset'
 
 export default defineConfig({
-  e2e: nxE2EPreset(__dirname),
+  e2e: {
+    ...nxE2EPreset(__dirname),
+    baseUrl: 'http://localhost:4200',
+  },
 })

--- a/apps/devchoices-next-e2e/src/e2e/app.cy.ts
+++ b/apps/devchoices-next-e2e/src/e2e/app.cy.ts
@@ -1,13 +1,62 @@
-import { getGreeting } from '../support/app.po'
+import '@testing-library/cypress/add-commands'
+
+import { questions } from '@benjamincode/shared/assets'
 
 describe('devchoices-next', () => {
-  beforeEach(() => cy.visit('/'))
+  it('should redirect to an existing question page when visiting home page', () => {
+    cy.visit('/')
 
-  it('should display welcome message', () => {
-    // Custom command example, see `../support/commands.ts` file
-    cy.login('my-email@something.com', 'myPassword')
+    cy.url()
+      .should('contain', '/question/')
+      .then((url) => {
+        const pathname = new URL(url).pathname
+        const match = pathname.match(new RegExp('^/question/(?<slug>.*)/$'))
+        const slug = match.groups.slug
+        const question = questions.find((question) => question.slug === slug)
 
-    // Function helper example, see `../support/app.po.ts` file
-    getGreeting().contains('Welcome devchoices-next')
+        expect(question).to.exist
+      })
+  })
+
+  it('should display question when visiting question page', () => {
+    const question = questions[0]
+
+    cy.visit(`/question/${question.slug}`)
+
+    cy.findByRole('heading', { name: question.choiceLeft.title }).should('exist')
+    cy.findByRole('img', { name: 'illustration for left choice' }).should(
+      'have.attr',
+      'src',
+      question.choiceLeft.img_path
+    )
+
+    cy.findByRole('heading', { name: question.choiceRight.title }).should('exist')
+    cy.findByRole('img', { name: 'illustration for right choice' }).should(
+      'have.attr',
+      'src',
+      question.choiceRight.img_path
+    )
+  })
+
+  it('should display percentages and votes when answering a question', () => {
+    const question = questions[0]
+
+    cy.visit(`/question/${question.slug}`)
+
+    cy.findByRole('heading', { name: question.choiceRight.title }).click()
+
+    cy.findAllByText(/%/).should('have.length', 2)
+    cy.findAllByText(/votes/i).should('have.length', 2)
+  })
+
+  it('should display next question when clicking next question button', () => {
+    const question = questions[0]
+
+    cy.visit(`/question/${question.slug}`)
+
+    cy.findByRole('heading', { name: question.choiceRight.title }).click()
+    cy.findByRole('button', { name: /next question/i }).click()
+
+    cy.url().should('contain', '/question/').should('not.contain', question.slug)
   })
 })

--- a/apps/devchoices-next-e2e/tsconfig.json
+++ b/apps/devchoices-next-e2e/tsconfig.json
@@ -4,7 +4,7 @@
     "sourceMap": false,
     "outDir": "../../dist/out-tsc",
     "allowJs": true,
-    "types": ["cypress", "node"]
+    "types": ["cypress", "node", "@testing-library/cypress"]
   },
   "include": ["src/**/*.ts", "src/**/*.js", "cypress.config.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@storybook/manager-webpack5": "~6.5.9",
     "@storybook/react": "~6.5.9",
     "@svgr/webpack": "^5.4.0",
+    "@testing-library/cypress": "^8.0.3",
     "@testing-library/react": "13.3.0",
     "@types/jest": "27.4.1",
     "@types/node": "16.11.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1118,7 +1118,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.8", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.14.8", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
   integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
@@ -3840,7 +3840,15 @@
   dependencies:
     tslib "^2.4.0"
 
-"@testing-library/dom@^8.5.0":
+"@testing-library/cypress@^8.0.3":
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-8.0.3.tgz#24ab34df34d7896866603ade705afbdd186e273c"
+  integrity sha512-nY2YaSbmuPo5k6kL0iLj/pGPPfka3iwb3kpTx8QN/vOCns92Saz9wfACqB8FJzcR7+lfA4d5HUOWqmTddBzczg==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    "@testing-library/dom" "^8.1.0"
+
+"@testing-library/dom@^8.1.0", "@testing-library/dom@^8.5.0":
   version "8.19.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.19.0.tgz#bd3f83c217ebac16694329e413d9ad5fdcfd785f"
   integrity sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==


### PR DESCRIPTION
# What this PR is about?

Add some e2e tests with Cypress: 
- should redirect to an existing question page when visiting home page
- should display question when visiting question page
- should display percentages and votes when answering a question
- should display next question when clicking next question button

Resolves #6 

### Tests

- [x] I have run the tests of the project. `nx affected --target=test `

### Clean Code

- [x] I made sure the code is type safe (no any)
