### PR TITLE
Feat/Vote with database

### DIFF
--- a/apps/devchoices-next/pages/question/[slug].tsx
+++ b/apps/devchoices-next/pages/question/[slug].tsx
@@ -57,8 +57,15 @@ export function QuestionPage(props: QuestionPageProps) {
 
   useEffect(() => {
     // todo replace with values fetched from database
+    fetch(`http://localhost:8000?slug=${slug}`)
+      .then((res) => res.json())
+      .then((data) => {
+        const left = data.find((v) => v.position === 0) || { count: 0 }
+        const right = data.find((v) => v.position === 1) || { count: 0 }
+        setVoteValues([+left.count, +right.count])
+      })
     setVoteValues([Math.trunc(Math.random() * 1000), Math.trunc(Math.random() * 1000)])
-  }, [setVoteValues])
+  }, [setVoteValues, slug])
 
   useEffect(() => {
     const nextQuestion = computeNextQuestion()
@@ -82,12 +89,25 @@ export function QuestionPage(props: QuestionPageProps) {
 
   const onLeft = () => {
     // todo store the +1 in the database
+    const form = new FormData()
+    form.append('position', '0')
+    fetch(`http://localhost:8000/?slug=${slug}`, {
+      method: 'POST',
+      body: form,
+    })
+    setVoteValues([voteValues[0] + 1, voteValues[1]])
     setShowResult(true)
   }
 
   const onRight = () => {
     // todo store the +1 in the database
-
+    const form = new FormData()
+    form.append('position', '1')
+    fetch(`http://localhost:8000/?slug=${slug}`, {
+      method: 'POST',
+      body: form,
+    })
+    setVoteValues([voteValues[0], voteValues[1] + 1])
     setShowResult(true)
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+    db:
+        platform: linux/x86_64
+        image: mysql:8
+        ports:
+            - 127.0.0.1:3306:3306
+        volumes:
+            - mysql-data:/var/lib/mysql
+        environment:
+            - MYSQL_ALLOW_EMPTY_PASSWORD=true
+volumes:
+  mysql-data:

--- a/php/coucou.sql
+++ b/php/coucou.sql
@@ -1,0 +1,12 @@
+CREATE TABLE votes (
+  slug VARCHAR(255) NOT NULL,
+  slot INT NOT NULL DEFAULT 0,
+  count INT DEFAULT NULL,
+  position INT NOT NULL,
+  UNIQUE KEY slug_slot (slug,slot,position)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE logs (
+  ip VARCHAR(255) NOT NULL,
+  slugs TEXT NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/php/index.php
+++ b/php/index.php
@@ -1,0 +1,66 @@
+<?php
+
+header("Access-Control-Allow-Origin: *");
+
+$pdo = new PDO("mysql:dbname=coucou;host=127.0.0.1", "root", "");
+$method = $_SERVER['REQUEST_METHOD'];
+$slug = $_GET['slug'] ?? null;
+$dispatchCountOn = 50;
+$ip = $_SERVER["REMOTE_ADDR"];
+
+if ($slug === null) {
+  die;
+}
+
+if ($method === 'GET') {
+  $query = $pdo->prepare('SELECT SUM(count) as count, position FROM votes WHERE slug = ? GROUP BY position');
+  $query->execute([$slug]);
+  $result = $query->fetchAll(PDO::FETCH_ASSOC);
+
+  echo json_encode($result);
+  return;
+}
+
+if ($method === 'POST') {
+  $position = $_POST['position'] ?? null;
+
+  if ($position === null) {
+    die;
+  }
+
+  $hashedIp = sha1($ip);
+  $query = $pdo->prepare('SELECT * FROM logs WHERE ip = ?');
+  $query->execute([$hashedIp]);
+
+  $result = $query->fetch(PDO::FETCH_ASSOC);
+
+  if ($result === false) {
+    $query = $pdo->prepare('INSERT INTO logs (ip, slugs) VALUES (?, ?);');
+    $query->execute([$hashedIp, json_encode([$slug])]);
+
+    insertVote($pdo, $slug, $position, $dispatchCountOn);
+    return;
+  }
+
+  $alreadyVotedFor = json_decode($result['slugs'], true);
+  $found = in_array($slug, $alreadyVotedFor);
+
+  if (!$found) {
+    array_push($alreadyVotedFor, $slug);
+
+    insertVote($pdo, $slug, $position, $dispatchCountOn);
+    $query = $pdo->prepare('UPDATE logs SET slugs = ? WHERE ip = ?;');
+    $query->execute([
+      json_encode($alreadyVotedFor),
+      $hashedIp
+    ]);
+  }
+
+  return;
+}
+
+function insertVote(PDO $pdo, string $slug, int $position, int $dispatchCountOn)
+{
+  $query = $pdo->prepare('INSERT INTO votes (slug, slot, count, position) VALUES (?, RAND() * '. $dispatchCountOn .', 1, ?) ON DUPLICATE KEY UPDATE count = count + 1;');
+  $query->execute([$slug, $position]);
+}


### PR DESCRIPTION
Co-authored-by: Romain Lanz <RomainLanz@users.noreply.github.com>

# What this PR is about?

Add database connection for vote

## If it's a new feature

- [x] `feature` Create a PHP script to add vote endpoints with ip verification
- [x] `feature` Add MYSQL database support
- [x] `feature` Add vote on the front side
- [ ] `feature` Add env to connect the real database
- [ ] `feature` Disable vote behavior if user has already vote on the front side

### Tests

- [x] I have run the tests of the project. `nx affected --target=test `

### Clean Code

- [x] I made sure the code is type safe (no any)
