### PR TITLE
Fix CORS header (remove wildcard) + allow only GET and POST method

### DIFF
--- a/php/api.php
+++ b/php/api.php
@@ -1,6 +1,9 @@
 <?php
 
-header("Access-Control-Allow-Origin: *");
+if (isset($_SERVER['HTTP_ORIGIN']))
+  header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
+header('Access-Control-Allow-Methods: GET, POST');
+
 include('../../config.php');
 
 $pdo = new PDO("mysql:dbname=" . $config['DB_NAME'] . ";host=" . $config['DB_HOST'], $config['DB_USER'], $config['DB_PASSWORD']);


### PR DESCRIPTION
Access-Control-Allow-Origin: * makes everyone able to request to your api

only allow the current origin, since it's an opensource project, I didn't wrote the actual domain (choiceof.dev) but the user's http origin instead