### PR TITLE
fix: use MATOMO_URL in app script tag

### DIFF
--- a/apps/devchoices-next/pages/_app.tsx
+++ b/apps/devchoices-next/pages/_app.tsx
@@ -105,7 +105,7 @@ function CustomApp({ Component, pageProps, router }: AppProps) {
           _paq.push(['trackPageView']);
           _paq.push(['enableLinkTracking']);
           (function() {
-          var u="//choiceof.dev/matomo/";
+          var u="${MATOMO_URL}";
           _paq.push(['setTrackerUrl', u+'matomo.php']);
           _paq.push(['setSiteId', '1']);
           var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];


### PR DESCRIPTION
Because otherwise running the site locally would ping your domain for no reason 😉 